### PR TITLE
Implement chat UI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ ChatSpend is a chat-based expense tracker built with Next.js and Supabase.
 2. Run `npm install`.
 3. Run `psql < scripts/setup.sql` in Supabase SQL editor to create tables.
 4. Start dev server with `npm run dev` and visit `/signup` to create an account.
+5. Try the expense parser by sending a POST to `/api/parse` with `{ "text": "Spent $5 on coffee" }` or use the `/chat` page.

--- a/docs/delivery/PBI-2/PBI-2-001.md
+++ b/docs/delivery/PBI-2/PBI-2-001.md
@@ -6,6 +6,7 @@ Initial work for PBI-2.
 ## Status History
 - Proposed
 - In Progress
+- Done
 
 ## Requirements
 - Follow PRD for PBI-2

--- a/docs/delivery/PBI-3/PBI-3-001.md
+++ b/docs/delivery/PBI-3/PBI-3-001.md
@@ -5,15 +5,22 @@ Initial work for PBI-3.
 
 ## Status History
 - Proposed
+- In Progress
 
 ## Requirements
 - Follow PRD for PBI-3
 
 ## Implementation Plan
-- TBD
+- Create `/chat` page with message list and input bar.
+- Call `/api/parse` to process user input and display bot response.
+- Link to chat from home page.
 
 ## Verification
-- TBD
+- `npm run lint`
+- `npm run test`
+- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=abc npm run build`
 
 ## Files Modified
-- TBD
+- src/app/chat/page.tsx (new)
+- src/app/page.tsx
+- docs/delivery/PBI-3/PBI-3-001.md

--- a/docs/delivery/backlog.md
+++ b/docs/delivery/backlog.md
@@ -3,7 +3,7 @@
 | PBI ID | Title | Status |
 |-------|------|--------|
 | PBI-1 | Auth/DB | Done |
-| PBI-2 | Expense NLP | In Progress |
+| PBI-2 | Expense NLP | Done |
 | PBI-3 | Chat UI | Proposed |
 | PBI-4 | Insights | Proposed |
 | PBI-5 | SMS/Telegram | Proposed |

--- a/docs/delivery/memory-log.md
+++ b/docs/delivery/memory-log.md
@@ -18,3 +18,9 @@
 
 ## Entry 6
 - Started PBI-2-001 to implement NLP parsing endpoint
+
+## Entry 7
+- Completed PBI-2-001 with OpenAI parse endpoint and test. Next: begin PBI-3-001 chat UI skeleton.
+
+## Entry 8
+- Started PBI-3-001 and implemented basic chat page linking to parse API.

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useState } from 'react';
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<{ role: string; content: string }[]>([]);
+  const [input, setInput] = useState('');
+
+  async function sendMessage(e: React.FormEvent) {
+    e.preventDefault();
+    const userMessage = { role: 'user', content: input };
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+    const res = await fetch('/api/parse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: input }),
+    });
+    const { data } = await res.json();
+    const botMessage = { role: 'assistant', content: JSON.stringify(data) };
+    setMessages(prev => [...prev, botMessage]);
+  }
+
+  return (
+    <main>
+      <h1>Chat</h1>
+      <div aria-live="polite">
+        {messages.map((m, i) => (
+          <p key={i} className={m.role === 'user' ? 'text-right' : ''}>{m.content}</p>
+        ))}
+      </div>
+      <form onSubmit={sendMessage}>
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Enter expense..."
+        />
+        <button type="submit">Send</button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 export default function HomePage() {
   return (
     <main>
-      {/* TODO: replace with actual content */}
       <h1>Welcome to ChatSpend</h1>
+      <p><a href="/chat">Open Chat</a></p>
+      <p><a href="/login">Login</a></p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- finish PBI-2-001 documentation updates
- log completion in memory log
- move to PBI-3 and add Chat page linking to parse endpoint
- update backlog and README instructions

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=abc npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c507e3db483328ffbb2572ec33a01