### PR TITLE
Add MobileNav component and tests

### DIFF
--- a/__tests__/MobileNav.test.tsx
+++ b/__tests__/MobileNav.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MobileNav from '../src/components/MobileNav';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+it('renders links and navigates via router', async () => {
+  const push = jest.fn();
+  (useRouter as jest.Mock).mockReturnValue({ push });
+  const user = userEvent.setup();
+  render(<MobileNav />);
+  const chatLink = screen.getByRole('link', { name: /chat/i });
+  const historyLink = screen.getByRole('link', { name: /history/i });
+  expect(chatLink).toBeInTheDocument();
+  expect(historyLink).toBeInTheDocument();
+  await user.click(chatLink);
+  expect(push).toHaveBeenCalledWith('/chat');
+  await user.click(historyLink);
+  expect(push).toHaveBeenCalledWith('/history');
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,3 +7,20 @@ body {
 .text-right {
   text-align: right;
 }
+
+.mobile-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  background: #eee;
+  padding: 0.5rem 0;
+}
+
+@media (min-width: 640px) {
+  .mobile-nav {
+    display: none;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,14 @@
 import './globals.css';
 import { ReactNode } from 'react';
+import MobileNav from '@/components/MobileNav';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <MobileNav />
+      </body>
     </html>
   );
 }

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { useRouter } from 'next/router';
+
+export default function MobileNav() {
+  const router = useRouter();
+  function handleClick(path: string, e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    router.push(path);
+  }
+  return (
+    <nav className="mobile-nav">
+      <a href="/chat" onClick={e => handleClick('/chat', e)}>Chat</a>
+      <a href="/history" onClick={e => handleClick('/history', e)}>History</a>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add MobileNav component with chat and history links
- include MobileNav in root layout
- hide nav on larger screens with CSS
- test navigation behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c74b0e174833288827c2bfcef7714