### PR TITLE
Route questions to chat API

### DIFF
--- a/__tests__/ChatPage.test.tsx
+++ b/__tests__/ChatPage.test.tsx
@@ -32,3 +32,18 @@ test('routes questions to insights API', async () => {
   await waitFor(() => expect(screen.getByText('You spent $5')).toBeInTheDocument());
   expect(global.fetch).toHaveBeenCalledWith('/api/chat', expect.anything());
 });
+
+test('shows question message and response', async () => {
+  const user = userEvent.setup();
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    json: () => Promise.resolve({ data: '42' }),
+  });
+  render(<ChatPage />);
+  await user.type(screen.getByPlaceholderText('Enter expense...'), 'How much?');
+  await user.click(screen.getByRole('button', { name: /send/i }));
+  await waitFor(() => {
+    expect(screen.getByText('How much?')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+  expect(global.fetch).toHaveBeenCalledWith('/api/chat', expect.anything());
+});

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -29,19 +29,8 @@ export default function ChatPage() {
   return (
     <main>
       <h1>Chat</h1>
-      <div aria-live="polite">
-        {messages.map((m, i) => (
-          <p key={i} className={m.role === 'user' ? 'text-right' : ''}>{m.content}</p>
-        ))}
-      </div>
-      <form onSubmit={sendMessage}>
-        <input
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          placeholder="Enter expense..."
-        />
-        <button type="submit">Send</button>
-      </form>
+      <MessageList messages={messages} />
+      <InputBar value={input} onChange={setInput} onSubmit={sendMessage} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- detect questions in ChatPage and route to /api/chat
- show assistant responses using existing components
- test that questions are routed correctly and conversation is updated

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c74a97b508332b45311c92565e3a8