### PR TITLE
Improve chat accessibility

### DIFF
--- a/__tests__/InputBar.test.tsx
+++ b/__tests__/InputBar.test.tsx
@@ -7,9 +7,11 @@ it('calls onChange and onSubmit', async () => {
   const handleSubmit = jest.fn();
   const user = userEvent.setup();
   render(<InputBar value="" onChange={handleChange} onSubmit={handleSubmit} />);
-  const input = screen.getByPlaceholderText('Enter expense...');
+  const input = screen.getByRole('textbox', { name: /message/i });
+  expect(input).toHaveFocus();
   await user.type(input, 'coffee');
   expect(handleChange).toHaveBeenCalled();
-  await user.click(screen.getByRole('button', { name: /send/i }));
+  await user.click(screen.getByRole('button', { name: /send message/i }));
   expect(handleSubmit).toHaveBeenCalled();
+  expect(input).toHaveFocus();
 });

--- a/__tests__/MessageList.test.tsx
+++ b/__tests__/MessageList.test.tsx
@@ -7,6 +7,8 @@ test('renders messages with user alignment', () => {
     { role: 'assistant', content: 'hello' },
   ];
   render(<MessageList messages={messages} />);
+  const list = screen.getByRole('list');
+  expect(list).toHaveAttribute('aria-live', 'polite');
   const items = screen.getAllByRole('listitem');
   expect(items[0]).toHaveClass('text-right');
   expect(items[0]).toHaveTextContent('hi');

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,21 @@
+:root {
+  --bg-color: #fff;
+  --text-color: #000;
+}
+
+@media (prefers-contrast: more) {
+  :root {
+    --bg-color: #000;
+    --text-color: #fff;
+  }
+}
+
 body {
   font-family: sans-serif;
   margin: 0;
   padding: 0;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 
 .text-right {

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,4 +1,4 @@
-import { FormEvent } from 'react';
+import { FormEvent, useEffect, useRef } from 'react';
 
 export default function InputBar({
   value,
@@ -9,20 +9,30 @@ export default function InputBar({
   onChange: (value: string) => void;
   onSubmit: () => void;
 }) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     onSubmit();
+    inputRef.current?.focus();
   }
 
   return (
     <form onSubmit={handleSubmit} className="flex gap-2 mt-2">
       <input
+        ref={inputRef}
+        id="chat-input"
+        aria-label="Message"
         className="flex-1"
         value={value}
         onChange={e => onChange(e.target.value)}
         placeholder="Enter expense..."
       />
-      <button type="submit">Send</button>
+      <button type="submit" aria-label="Send message">Send</button>
     </form>
   );
 }

--- a/src/components/MessageList.tsx
+++ b/src/components/MessageList.tsx
@@ -6,20 +6,24 @@ export interface Message {
 }
 
 export default function MessageList({ messages }: { messages: Message[] }) {
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const bottomRef = useRef<HTMLLIElement>(null);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
   return (
-    <ul aria-live="polite">
+    <ul role="list" aria-live="polite">
       {messages.map((m, i) => (
-        <li key={i} className={m.role === 'user' ? 'text-right' : ''}>
+        <li role="listitem" key={i} className={m.role === 'user' ? 'text-right' : ''}>
           {m.content}
         </li>
       ))}
-      <div ref={bottomRef} />
+      <li
+        aria-hidden="true"
+        ref={bottomRef}
+        style={{ listStyle: 'none', height: 0 }}
+      />
     </ul>
   );
 }


### PR DESCRIPTION
## Summary
- enhance `<MessageList>` semantics using `<ul>`/`<li>` and ARIA roles
- focus management and ARIA labels in `<InputBar>`
- add high contrast CSS variables
- update tests for accessibility attributes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c74b6720c8332ad1e8ed360141580