### PR TITLE
Implement responsive layouts

### DIFF
--- a/__tests__/ChatPage.test.tsx
+++ b/__tests__/ChatPage.test.tsx
@@ -32,3 +32,8 @@ test('routes questions to insights API', async () => {
   await waitFor(() => expect(screen.getByText('You spent $5')).toBeInTheDocument());
   expect(global.fetch).toHaveBeenCalledWith('/api/chat', expect.anything());
 });
+
+test('has responsive layout container', () => {
+  render(<ChatPage />);
+  expect(screen.getByRole('main')).toHaveClass('app-container');
+});

--- a/__tests__/HistoryPage.test.tsx
+++ b/__tests__/HistoryPage.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+jest.mock('../src/lib/supabaseClient', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn(() => ({ limit: jest.fn(() => ({ data: [] })) })),
+    })),
+  },
+}));
+
+import HistoryPage from '../src/app/history/page';
+
+test('renders responsive layout container', () => {
+  render(<HistoryPage />);
+  expect(screen.getByRole('main')).toHaveClass('app-container');
+});

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -27,21 +27,15 @@ export default function ChatPage() {
   }
 
   return (
-    <main>
-      <h1>Chat</h1>
-      <div aria-live="polite">
-        {messages.map((m, i) => (
-          <p key={i} className={m.role === 'user' ? 'text-right' : ''}>{m.content}</p>
-        ))}
-      </div>
-      <form onSubmit={sendMessage}>
-        <input
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          placeholder="Enter expense..."
-        />
-        <button type="submit">Send</button>
-      </form>
+    <main className="app-container">
+      <nav className="sidebar">
+        <a href="/history">History</a>
+      </nav>
+      <section className="content">
+        <h1>Chat</h1>
+        <MessageList messages={messages} />
+        <InputBar value={input} onChange={setInput} onSubmit={sendMessage} />
+      </section>
     </main>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,40 @@ body {
   padding: 0;
 }
 
+.app-container {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 641px) {
+  .app-container {
+    flex-direction: row;
+  }
+}
+
+@media (min-width: 1024px) {
+  .app-container {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+  }
+}
+
+.sidebar {
+  padding: 1rem;
+  border-bottom: 1px solid #ccc;
+}
+
+.content {
+  padding: 1rem;
+}
+
+@media (min-width: 641px) {
+  .sidebar {
+    border-bottom: none;
+    border-right: 1px solid #ccc;
+  }
+}
+
 .text-right {
   text-align: right;
 }

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+interface Expense {
+  amount: number;
+  vendor: string;
+  category?: string;
+  ts?: string;
+}
+
+export default function HistoryPage() {
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const { data } = await supabase
+        .from('expenses')
+        .select('amount,vendor,category,ts')
+        .limit(20);
+      setExpenses(data || []);
+    }
+    load();
+  }, []);
+
+  return (
+    <main className="app-container">
+      <nav className="sidebar">
+        <a href="/chat">Chat</a>
+      </nav>
+      <section className="content">
+        <h1>History</h1>
+        <ul>
+          {expenses.map((e, i) => (
+            <li key={i}>
+              {e.ts || ''} - {e.vendor} ${e.amount}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement breakpoints in `globals.css`
- restructure `ChatPage` with sidebar and responsive classes
- create `HistoryPage` component and unit test
- update tests for responsive layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c74b4d98c83329a14bfc8af198b60