### PR TITLE
Add expense history page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ ChatSpend is a chat-based expense tracker built with Next.js and Supabase.
 3. Run `psql < scripts/setup.sql` in Supabase SQL editor to create tables.
 4. Start dev server with `npm run dev` and visit `/signup` to create an account.
 5. Try the expense parser by sending a POST to `/api/parse` with `{ "text": "Spent $5 on coffee" }` or use the `/chat` page. End your message with a question mark to receive insights, or call `/api/chat` directly with `{ "userId": "<id>", "question": "How much on coffee?" }`.
-6. Run `npm test` to execute unit tests.
+6. After installing dependencies, run `npm test` (or `npx jest`) to execute unit tests.

--- a/__tests__/HistoryPage.test.tsx
+++ b/__tests__/HistoryPage.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import HistoryPage from '../src/app/history/page';
+
+jest.mock('../src/lib/supabaseClient', () => ({
+  supabase: {
+    auth: { getUser: jest.fn() },
+    from: jest.fn(),
+  },
+}));
+
+import { supabase } from '../src/lib/supabaseClient';
+
+it('renders expenses from supabase', async () => {
+  (supabase.auth.getUser as jest.Mock).mockResolvedValue({ data: { user: { id: '1' } } });
+  const orderMock = jest.fn().mockResolvedValue({ data: [
+    { amount: 5, vendor: 'Coffee', category: 'Food', ts: '2024-01-01T00:00:00Z' }
+  ], error: null });
+  const eqMock = jest.fn(() => ({ order: orderMock }));
+  const selectMock = jest.fn(() => ({ eq: eqMock }));
+  (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+  render(<HistoryPage />);
+  await waitFor(() => expect(screen.getByText('Coffee')).toBeInTheDocument());
+  expect(screen.getByText('5')).toBeInTheDocument();
+});

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,0 +1,55 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+
+interface Expense {
+  amount: number;
+  vendor: string | null;
+  category: string | null;
+  ts: string;
+}
+
+export default function HistoryPage() {
+  const [expenses, setExpenses] = useState<Expense[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const { data: userData } = await supabase.auth.getUser();
+      const user = userData?.user;
+      if (!user) return;
+      const { data } = await supabase
+        .from('expenses')
+        .select('amount,vendor,category,ts')
+        .eq('user_id', user.id)
+        .order('ts', { ascending: false });
+      if (data) setExpenses(data as Expense[]);
+    }
+    load();
+  }, []);
+
+  return (
+    <main>
+      <h1>Expense History</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Amount</th>
+            <th>Vendor</th>
+            <th>Category</th>
+            <th>Timestamp</th>
+          </tr>
+        </thead>
+        <tbody>
+          {expenses.map(exp => (
+            <tr key={exp.ts + exp.vendor}>
+              <td>{exp.amount}</td>
+              <td>{exp.vendor}</td>
+              <td>{exp.category}</td>
+              <td>{new Date(exp.ts).toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ export default function HomePage() {
       <h1>Welcome to ChatSpend</h1>
       <p><a href="/chat">Open Chat</a></p>
       <p><a href="/login">Login</a></p>
+      <p><a href="/history">View Expense History</a></p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- create history page to display a user's expenses
- link history page from the homepage
- test history page with mocked Supabase calls
- clarify README instructions for running tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c74aef3d08332ab21192874055723