### PR TITLE
Audit and fix navigation hook

### DIFF
--- a/__tests__/MobileNav.test.tsx
+++ b/__tests__/MobileNav.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import MobileNav from '../src/components/MobileNav';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
-jest.mock('next/router', () => ({
+jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }));
 

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
 export default function MobileNav() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- switch MobileNav to use `next/navigation`
- update MobileNav test mocks for new module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c8029e8fc833284154cc682ad4230